### PR TITLE
fix usage of global variants

### DIFF
--- a/src/yaml/JMyers/homes-pack.yaml
+++ b/src/yaml/JMyers/homes-pack.yaml
@@ -1,6 +1,6 @@
 group: "jmyers2043"
 name: "homes-pack"
-version: "2.0"
+version: "2.0-1"
 subfolder: "200-residential"
 dependencies:
 - "bsc:essentials"
@@ -10,16 +10,16 @@ dependencies:
 - "bsc:texturepack-cycledogg-vol01"
 - "bsc:mega-props-jmyers-common-props"
 variants:
- - variant: { building-style: "no" }
+ - variant: { jmyers2043:homes-pack:building-style: "no" }
    assets:
    - assetId: "jmyers-homes-pack"
- - variant: { building-style: "yes" }
+ - variant: { jmyers2043:homes-pack:building-style: "yes" }
    dependencies: 
    - "null-45:allow-more-building-styles-dll"
    assets:
    - assetId: "jmyers-homes-pack"
 variantInfo:
-- variantId: "building-style"
+- variantId: "jmyers2043:homes-pack:building-style"
   description: This setting determines whether to install the version that supports additional building styles or the original version without support for additional styles activated
   values:
   - value: "no"

--- a/src/yaml/Rubik/wtc-complex.yaml
+++ b/src/yaml/Rubik/wtc-complex.yaml
@@ -140,16 +140,16 @@ dependencies:
 - "bsc:mega-props-rubik3-vol01-wtc-props"
 - "bsc:textures-vol01"
 - "bsc:textures-vol03"
-version: "2.0"
+version: "2.0-1"
 subfolder: "300-commercial"
 variants:
-- variant: { cam: "yes" }
+- variant: { CAM: "yes" }
   assets:
   - assetId: "bsc-rubik-wtc-complex"
     include:
     - "Two World Trade with Jobs.dat"
     - "One World Trade with Jobs.dat"
-- variant: { cam: "no" }
+- variant: { CAM: "no" }
   assets:
   - assetId: "bsc-rubik-wtc-complex"
     exclude:

--- a/src/yaml/Rubik/wtc-complex.yaml
+++ b/src/yaml/Rubik/wtc-complex.yaml
@@ -154,7 +154,7 @@ variants:
   - assetId: "bsc-rubik-wtc-complex"
     exclude:
     - "Two World Trade with Jobs.dat"
-    - "One World Trade with Jobs.dat\""
+    - "One World Trade with Jobs.dat"
 info:
   summary: "BSC Rubik One and Two Trade Center by Rubik3"
   description: |


### PR DESCRIPTION
See https://github.com/sebamarynissen/simtropolis-channel/pull/254 for details.

Side note regarding the JMyers Homes Pack: The package is already in the main channel, so not needed here. Adding a separate building-style variant is not needed I'd say, since, similarly to the Submenus DLL, it's an optional dependency. If you want that functionality, you can simply install the DLL. But having the `building-style` variant here can be a bit confusing, as it installs the same thing in both cases, so choosing "no" doesn't magically disable the building styles for this package if you have the DLL.