### PR TITLE
metadata: update Rubik's WTC complex

### DIFF
--- a/src/yaml/Rubik/wtc-complex.yaml
+++ b/src/yaml/Rubik/wtc-complex.yaml
@@ -5,22 +5,7 @@ url: "https://www.sc4evermore.com/index.php/downloads?task=download.send&id=279:
 
 ---
 group: "bsc"
-name: "mega-props-rubik3-vol01-wtc-props"
-version: "2.0"
-subfolder: "100-props-textures"
-assets:
-- assetId: "bsc-rubik-wtc-complex"
-  include: [ "/BSC MEGA Props - Rubik3 Vol01 - WTC Props v..dat" ]
-info:
-  summary: "BSC MEGA Props Rubik3 Vol01 - WTC Props by Rubik3"
-  author: "Rubik"
-  websites:
-    - "https://www.sc4evermore.com/index.php/downloads/download/20-ploppable/279-sc4d-lex-legacy-bsc-custodian-rubik-wtc-complex"
-    - "https://community.simtropolis.com/files/file/36354-wtc-complex-sc4d-lex-legacy-bsc-custodian-rubik/"
-
----
-group: "bsc"
-name: "bsc-rubik-world-trade-center-complex"
+name: "rubik-world-trade-center-complex"
 dependencies:
 - "bsc:essentials"
 - "bsc:mega-props-sg-vol01"
@@ -31,7 +16,7 @@ dependencies:
 - "bsc:textures-vol03"
 - "lord-quillian2:foss-construction-tower-crane"
 - "memo:submenus-dll"
-version: "2.0"
+version: "2.0-1"
 subfolder: "360-landmark"
 assets:
 - assetId: "bsc-rubik-wtc-complex"
@@ -131,7 +116,7 @@ info:
     - https://www.sc4evermore.com/images/jdownloads/screenshots/Night1.jpg
 ---
 group: "bsc"
-name: "bsc-rubik-one-and-two-trade-center"
+name: "rubik-one-and-two-trade-center"
 dependencies:
 - "bsc:essentials"
 - "bsc:mega-props-sg-vol01"
@@ -140,7 +125,7 @@ dependencies:
 - "bsc:mega-props-rubik3-vol01-wtc-props"
 - "bsc:textures-vol01"
 - "bsc:textures-vol03"
-version: "2.0-1"
+version: "2.0-2"
 subfolder: "300-commercial"
 variants:
 - variant: { CAM: "yes" }


### PR DESCRIPTION
Remove rubik's props in favor of including them in the main channel (https://github.com/memo33/sc4pac/pull/135). Also removed the redundant double `bsc` from the package names. Build will fail until the linked PR is merged.